### PR TITLE
Append 'data' to operation interfaces

### DIFF
--- a/packages/graphql-typescript-definitions/src/print/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/index.ts
@@ -216,7 +216,7 @@ function printOperation(
     fragmentsReferenced,
   } = operation;
 
-  const document = new Document(`${operationName}${pascal(operationType)}`, operation);
+  const document = new Document(`${operationName}${pascal(operationType)}Data`, operation);
   context.document = document;
 
   context.addUsedExternalFragments(fragmentsReferenced);


### PR DESCRIPTION
Changes generated interfaces from `interface ProductsQuery` to `interface ProductsQueryData`, because it's the interface that represents the shape of the data object.

Also wanted to change the name of the document to `query` but this is totally an import-site detail, so nothing needs to change here at the moment. Unless you want it to. ¯\_(ツ)_/¯ 