### PR TITLE
Export simple types

### DIFF
--- a/packages/graphql-typescript-definitions/src/print/graphql.ts
+++ b/packages/graphql-typescript-definitions/src/print/graphql.ts
@@ -80,13 +80,13 @@ export function printRootGraphQLType(
     }, generator);
   } else if (type instanceof GraphQLEnumType) {
     const values = type.getValues();
-    generator.printOnNewline(`type ${type.name} = `);
+    generator.printOnNewline(`export type ${type.name} = `);
     values.forEach((value, index) => {
       generator.print(`'${value.value}'`);
       generator.print(index !== values.length - 1 && ' | ');
     });
     generator.print(';');
   } else if (type instanceof GraphQLScalarType) {
-    generator.printOnNewline(`type ${type.name} = string;`);
+    generator.printOnNewline(`export type ${type.name} = string;`);
   }
 }

--- a/packages/graphql-typescript-definitions/src/print/graphql.ts
+++ b/packages/graphql-typescript-definitions/src/print/graphql.ts
@@ -80,13 +80,13 @@ export function printRootGraphQLType(
     }, generator);
   } else if (type instanceof GraphQLEnumType) {
     const values = type.getValues();
-    generator.printOnNewline(`export type ${type.name} = `);
+    generator.print(`type ${type.name}Enum = `);
     values.forEach((value, index) => {
       generator.print(`'${value.value}'`);
       generator.print(index !== values.length - 1 && ' | ');
     });
     generator.print(';');
   } else if (type instanceof GraphQLScalarType) {
-    generator.printOnNewline(`export type ${type.name} = string;`);
+    generator.print(`type ${type.name} = string;`);
   }
 }

--- a/packages/graphql-typescript-definitions/src/print/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/index.ts
@@ -191,6 +191,14 @@ function printFragment(
   if (document.fieldObjects.length) {
     printExport(() => {
       printNamespace(document.name, () => {
+        Array.from(context.typesUsed).reverse().forEach((type) => {
+          if (type instanceof GraphQLEnumType) {
+            printExport(() => {
+              generator.print(`type ${type.name} = ${type.name}Enum;`);
+            }, generator);
+          }
+        });
+
         for (const fieldObject of document.fieldObjects) {
           printFieldObject(fieldObject, generator, context);
           generator.printEmptyLine();
@@ -308,7 +316,7 @@ function printField(
     }
   } else if (finalType instanceof GraphQLEnumType) {
     context.addUsedType(finalType);
-    generator.print(finalType.name);
+    generator.print(`${finalType.name}Enum`);
   } else {
     const fieldObject = context.document.fieldObjectForField(field);
     generator.print(`${context.document.name}.${fieldObject.name}`);

--- a/packages/graphql-typescript-definitions/src/print/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/index.ts
@@ -64,7 +64,7 @@ export function printFile({operations, fragments, path}: File, ast: AST) {
     }
 
     printImport({
-      specifiers: Array.from(specifiers),
+      specifiers: Array.from(specifiers).map((specifier: String) => `${specifier}Data`),
       source: relativePath,
     }, generator);
   });

--- a/packages/graphql-typescript-definitions/src/print/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/index.ts
@@ -64,7 +64,7 @@ export function printFile({operations, fragments, path}: File, ast: AST) {
     }
 
     printImport({
-      specifiers: Array.from(specifiers).map((specifier: String) => `${specifier}Data`),
+      specifiers: Array.from(specifiers).map((specifier) => `${specifier}Data`),
       source: relativePath,
     }, generator);
   });

--- a/packages/graphql-typescript-definitions/src/print/index.ts
+++ b/packages/graphql-typescript-definitions/src/print/index.ts
@@ -73,13 +73,20 @@ export function printFile({operations, fragments, path}: File, ast: AST) {
 
   Array.from(context.specialTypesUsed).reverse().forEach((type) => {
     type.print(generator);
-    generator.printEmptyLine();
   });
 
-  Array.from(context.typesUsed).reverse().forEach((type) => {
-    printRootGraphQLType(type, generator);
+  const typesUsed = Array.from(context.typesUsed).reverse();
+  if (typesUsed.length > 0) {
+    printExport(() => {
+      printNamespace('Schema', () => {
+        Array.from(context.typesUsed).reverse().forEach((type) => {
+          printExport(() => printRootGraphQLType(type, generator), generator);
+          generator.printEmptyLine();
+        });
+      }, generator);
+    }, generator);
     generator.printEmptyLine();
-  });
+  }
 
   generator.printOnNewline(subGenerator.output);
 
@@ -312,11 +319,11 @@ function printField(
       generator.print(builtInScalarMap[finalType.name]);
     } else {
       context.addUsedType(finalType);
-      generator.print(finalType.name);
+      generator.print(`Schena.${finalType.name}`);
     }
   } else if (finalType instanceof GraphQLEnumType) {
     context.addUsedType(finalType);
-    generator.print(`${finalType.name}Enum`);
+    generator.print(`Schema.${finalType.name}`);
   } else {
     const fieldObject = context.document.fieldObjectForField(field);
     generator.print(`${context.document.name}.${fieldObject.name}`);

--- a/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/cli.test.ts.snap
@@ -11,7 +11,7 @@ Object {
   "stderr": "",
   "stdout": " ERROR  Syntax Error packages/graphql-typescript-definitions/test/fixtures/malformed-query/documents/Fragment.graphql (2:3) Expected {, found Name \\"name\\"
 
-1: fragment Person on Person
+1: fragment PersonFields on Person
 2:   name
      ^
 3:   relatives {

--- a/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
@@ -6,7 +6,9 @@ exports[` 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-type KindEnum = 'CAT' | 'DOG';
+export namespace Schema {
+  export type KindEnum = 'CAT' | 'DOG';
+}
 
 export interface PersonQueryData {
   person: PersonQueryData.Person,
@@ -31,7 +33,7 @@ export namespace PetQueryData {
 }
 
 export interface PetDetailsFragmentData {
-  kind: KindEnum,
+  kind: Schema.Kind,
 }
 
 export interface FavoritePetFragmentData {
@@ -58,10 +60,12 @@ exports[`printFile() custom scalars declares them as strings 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-type DateTime = string;
+export namespace Schema {
+  export type DateTime = string;
+}
 
 export interface DateQueryData {
-  date: DateTime,
+  date: Schena.DateTime,
 }
 
 declare const document: DocumentNode;
@@ -77,10 +81,12 @@ exports[`printFile() custom scalars declares them as strings 2`] = `
 
 import {DocumentNode} from 'graphql';
 
-type DateTime = string;
+export namespace Schema {
+  export type DateTime = string;
+}
 
 export interface DateQueryData {
-  date?: DateTime | null,
+  date?: Schena.DateTime | null,
 }
 
 declare const document: DocumentNode;
@@ -96,10 +102,12 @@ exports[`printFile() enum types prints the enum type and its type declaration 1`
 
 import {DocumentNode} from 'graphql';
 
-type EpisodeEnum = 'ONE' | 'TWO' | 'THREE';
+export namespace Schema {
+  export type EpisodeEnum = 'ONE' | 'TWO' | 'THREE';
+}
 
 export interface WhichEpisodeQueryData {
-  episode: EpisodeEnum,
+  episode: Schema.Episode,
 }
 
 declare const document: DocumentNode;
@@ -115,10 +123,12 @@ exports[`printFile() enum types prints the enum type and its type declaration 2`
 
 import {DocumentNode} from 'graphql';
 
-type EpisodeEnum = 'ONE' | 'TWO' | 'THREE';
+export namespace Schema {
+  export type EpisodeEnum = 'ONE' | 'TWO' | 'THREE';
+}
 
 export interface WhichEpisodeQueryData {
-  episode?: EpisodeEnum | null,
+  episode?: Schema.Episode | null,
 }
 
 declare const document: DocumentNode;
@@ -158,7 +168,6 @@ import {PersonDetailsFragmentData, EntityNameFragmentData} from './subfolder/ano
 type NullableFragment<T> = {
   [P in keyof T]?: T[P] | null
 }
-
 export interface PetsFragmentData extends NullableFragment<PetKindFragmentData>, NullableFragment<PersonDetailsFragmentData>, EntityNameFragmentData {
   id: string,
 }
@@ -176,11 +185,13 @@ exports[`printFile() fragments prints inline fragments 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-type KindEnum = 'DOG' | 'CAT';
+export namespace Schema {
+  export type KindEnum = 'DOG' | 'CAT';
+}
 
 export interface PetsFragmentData {
   id: string,
-  kind?: KindEnum | null,
+  kind?: Schema.Kind | null,
   name: string,
   nickname?: string | null,
   favoritePet?: PetsFragmentData.Pet | null,
@@ -340,7 +351,6 @@ import {EntityNameFragmentData} from './subfolder/MyFragment.graphql';
 type NullableFragment<T> = {
   [P in keyof T]?: T[P] | null
 }
-
 export interface EntitiesQueryData {
   entities: EntitiesQueryData.Entity[],
 }
@@ -639,19 +649,21 @@ exports[`printFile() variables prints out a variable interface and all associate
 
 import {DocumentNode} from 'graphql';
 
-interface Language {
-  code?: string | null,
-}
+export namespace Schema {
+  export interface Language {
+    code?: string | null,
+  }
 
-type DateTime = string;
+  export type DateTime = string;
 
-type StyleEnum = 'FULL' | 'NICK';
+  export type StyleEnum = 'FULL' | 'NICK';
 
-interface NameInput {
-  style: Style,
-  date?: DateTime | null,
-  excited: boolean,
-  language?: Language | null,
+  export interface NameInput {
+    style: Style,
+    date?: DateTime | null,
+    excited: boolean,
+    language?: Language | null,
+  }
 }
 
 export interface NameQueryData {

--- a/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
@@ -6,7 +6,7 @@ exports[` 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-type Kind = 'CAT' | 'DOG';
+export type Kind = 'CAT' | 'DOG';
 
 export interface PersonQueryData {
   person: PersonQueryData.Person,
@@ -57,7 +57,7 @@ exports[`printFile() custom scalars declares them as strings 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-type DateTime = string;
+export type DateTime = string;
 
 export interface DateQueryData {
   date: DateTime,
@@ -76,7 +76,7 @@ exports[`printFile() custom scalars declares them as strings 2`] = `
 
 import {DocumentNode} from 'graphql';
 
-type DateTime = string;
+export type DateTime = string;
 
 export interface DateQueryData {
   date?: DateTime | null,
@@ -95,7 +95,7 @@ exports[`printFile() enum types prints the enum type and its type declaration 1`
 
 import {DocumentNode} from 'graphql';
 
-type Episode = 'ONE' | 'TWO' | 'THREE';
+export type Episode = 'ONE' | 'TWO' | 'THREE';
 
 export interface WhichEpisodeQueryData {
   episode: Episode,
@@ -114,7 +114,7 @@ exports[`printFile() enum types prints the enum type and its type declaration 2`
 
 import {DocumentNode} from 'graphql';
 
-type Episode = 'ONE' | 'TWO' | 'THREE';
+export type Episode = 'ONE' | 'TWO' | 'THREE';
 
 export interface WhichEpisodeQueryData {
   episode?: Episode | null,
@@ -175,7 +175,7 @@ exports[`printFile() fragments prints inline fragments 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-type Kind = 'DOG' | 'CAT';
+export type Kind = 'DOG' | 'CAT';
 
 export interface PetsFragmentData {
   id: string,
@@ -641,9 +641,9 @@ interface Language {
   code?: string | null,
 }
 
-type DateTime = string;
+export type DateTime = string;
 
-type Style = 'FULL' | 'NICK';
+export type Style = 'FULL' | 'NICK';
 
 interface NameInput {
   style: Style,

--- a/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
@@ -151,8 +151,8 @@ exports[`printFile() fragments prints fragment spreads 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-import {PetKindFragment} from './subfolder/PetKind.graphql';
-import {PersonDetailsFragment, EntityNameFragment} from './subfolder/another/PersonDetails.graphql';
+import {PetKindFragmentData} from './subfolder/PetKind.graphql';
+import {PersonDetailsFragmentData, EntityNameFragmentData} from './subfolder/another/PersonDetails.graphql';
 
 type NullableFragment<T> = {
   [P in keyof T]?: T[P] | null
@@ -333,7 +333,7 @@ exports[`printFile() object types fragment spreads prints a partial fragment typ
 
 import {DocumentNode} from 'graphql';
 
-import {EntityNameFragment} from './subfolder/MyFragment.graphql';
+import {EntityNameFragmentData} from './subfolder/MyFragment.graphql';
 
 type NullableFragment<T> = {
   [P in keyof T]?: T[P] | null
@@ -361,7 +361,7 @@ exports[`printFile() object types fragment spreads prints them as union types wh
 
 import {DocumentNode} from 'graphql';
 
-import {EntityNameFragment} from './subfolder/MyFragment.graphql';
+import {EntityNameFragmentData} from './subfolder/MyFragment.graphql';
 
 export interface EntitiesQueryData {
   entities: EntitiesQueryData.Entity[],

--- a/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
+++ b/packages/graphql-typescript-definitions/test/__snapshots__/print.test.ts.snap
@@ -6,7 +6,7 @@ exports[` 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-export type Kind = 'CAT' | 'DOG';
+type KindEnum = 'CAT' | 'DOG';
 
 export interface PersonQueryData {
   person: PersonQueryData.Person,
@@ -31,7 +31,7 @@ export namespace PetQueryData {
 }
 
 export interface PetDetailsFragmentData {
-  kind: Kind,
+  kind: KindEnum,
 }
 
 export interface FavoritePetFragmentData {
@@ -40,6 +40,7 @@ export interface FavoritePetFragmentData {
 }
 
 export namespace FavoritePetFragmentData {
+  export type Kind = KindEnum;
   export interface Pet extends PetDetailsFragmentData {
   }
 }
@@ -57,7 +58,7 @@ exports[`printFile() custom scalars declares them as strings 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-export type DateTime = string;
+type DateTime = string;
 
 export interface DateQueryData {
   date: DateTime,
@@ -76,7 +77,7 @@ exports[`printFile() custom scalars declares them as strings 2`] = `
 
 import {DocumentNode} from 'graphql';
 
-export type DateTime = string;
+type DateTime = string;
 
 export interface DateQueryData {
   date?: DateTime | null,
@@ -95,10 +96,10 @@ exports[`printFile() enum types prints the enum type and its type declaration 1`
 
 import {DocumentNode} from 'graphql';
 
-export type Episode = 'ONE' | 'TWO' | 'THREE';
+type EpisodeEnum = 'ONE' | 'TWO' | 'THREE';
 
 export interface WhichEpisodeQueryData {
-  episode: Episode,
+  episode: EpisodeEnum,
 }
 
 declare const document: DocumentNode;
@@ -114,10 +115,10 @@ exports[`printFile() enum types prints the enum type and its type declaration 2`
 
 import {DocumentNode} from 'graphql';
 
-export type Episode = 'ONE' | 'TWO' | 'THREE';
+type EpisodeEnum = 'ONE' | 'TWO' | 'THREE';
 
 export interface WhichEpisodeQueryData {
-  episode?: Episode | null,
+  episode?: EpisodeEnum | null,
 }
 
 declare const document: DocumentNode;
@@ -175,17 +176,18 @@ exports[`printFile() fragments prints inline fragments 1`] = `
 
 import {DocumentNode} from 'graphql';
 
-export type Kind = 'DOG' | 'CAT';
+type KindEnum = 'DOG' | 'CAT';
 
 export interface PetsFragmentData {
   id: string,
-  kind?: Kind | null,
+  kind?: KindEnum | null,
   name: string,
   nickname?: string | null,
   favoritePet?: PetsFragmentData.Pet | null,
 }
 
 export namespace PetsFragmentData {
+  export type Kind = KindEnum;
   export interface Pet {
     name: string,
   }
@@ -641,9 +643,9 @@ interface Language {
   code?: string | null,
 }
 
-export type DateTime = string;
+type DateTime = string;
 
-export type Style = 'FULL' | 'NICK';
+type StyleEnum = 'FULL' | 'NICK';
 
 interface NameInput {
   style: Style,

--- a/packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Fragment.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Fragment.graphql
@@ -1,4 +1,4 @@
-fragment Person on Person {
+fragment PersonFields on Person {
   name
   relatives {
     name

--- a/packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Query.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/all-clear/documents/Query.graphql
@@ -1,6 +1,6 @@
-query Query {
+query FindPerson {
   person {
     id
-    ...Person
+    ...PersonFields
   }
 }

--- a/packages/graphql-typescript-definitions/test/fixtures/malformed-query/documents/Fragment.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/malformed-query/documents/Fragment.graphql
@@ -1,4 +1,4 @@
-fragment Person on Person
+fragment PersonFields on Person
   name
   relatives {
     name

--- a/packages/graphql-typescript-definitions/test/fixtures/malformed-query/documents/Query.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/malformed-query/documents/Query.graphql
@@ -1,6 +1,6 @@
-query Query {
+query FindPerson {
   person {
     id
-    ...Person
+    ...PersonFields
   }
 }

--- a/packages/graphql-typescript-definitions/test/fixtures/missing-schema/documents/Fragment.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/missing-schema/documents/Fragment.graphql
@@ -1,4 +1,4 @@
-fragment Person on Person {
+fragment PersonFields on Person {
   name
   relatives {
     name

--- a/packages/graphql-typescript-definitions/test/fixtures/missing-schema/documents/Query.graphql
+++ b/packages/graphql-typescript-definitions/test/fixtures/missing-schema/documents/Query.graphql
@@ -1,6 +1,6 @@
-query Query {
+query FindPerson {
   person {
     id
-    ...Person
+    ...PersonFields
   }
 }


### PR DESCRIPTION
@lemonmade 

- Prefixes enum and scalar type defs with `export` so you can use them in your call sites
- Fixes fragment imports to use `Data` suffix
- Uses more specific names in test queries